### PR TITLE
Add billing status field choices and filtering endpoint

### DIFF
--- a/pet_clinic_billing_service/billing_service/models.py
+++ b/pet_clinic_billing_service/billing_service/models.py
@@ -7,13 +7,20 @@ class Billing(models.Model):
         ('medium', 'Medium'),
         ('high', 'High'),
     ]
+    
+    STATUS_CHOICES = [
+        ('pending', 'Pending'),
+        ('paid', 'Paid'),
+        ('overdue', 'Overdue'),
+        ('cancelled', 'Cancelled'),
+    ]
 
     owner_id   = models.IntegerField()
     type = models.CharField(max_length=200)
     type_name = models.CharField(max_length=200)
     pet_id = models.IntegerField()
     payment = models.DecimalField(max_digits=10, decimal_places=2)
-    status = models.CharField(max_length=20)
+    status = models.CharField(max_length=20, choices=STATUS_CHOICES, default='pending')
     priority = models.CharField(max_length=10, choices=PRIORITY_CHOICES, default='medium')
 
     class Meta:

--- a/pet_clinic_billing_service/billing_service/views.py
+++ b/pet_clinic_billing_service/billing_service/views.py
@@ -36,6 +36,18 @@ class BillingViewSet(viewsets.ViewSet):
         )
         serializer = BillingSerializer(queryset, many=True)
         return Response(serializer.data)
+        
+    @action(detail=False, methods=['get'], url_path='by-status/(?P<status_filter>[^/.]+)')
+    def by_status(self, request, status_filter=None):
+        """
+        Filter billings by status
+        """
+        invalid_names = CheckList.objects.values('invalid_name').distinct()[:100000]
+        queryset = Billing.objects.filter(status=status_filter).exclude(
+            type_name__in=Subquery(invalid_names)
+        )
+        serializer = BillingSerializer(queryset, many=True)
+        return Response(serializer.data)
 
     def list_v2(self, request):
         return Response({'version': 'v2', 'billings': serializer.data})


### PR DESCRIPTION
This PR adds status field choices and filtering functionality similar to the priority filtering feature.

## Changes:
- Add STATUS_CHOICES to Billing model with predefined status options (pending, paid, overdue, cancelled)
- Add by_status endpoint to filter billings by status
- Maintains consistency with existing priority filtering functionality
